### PR TITLE
Feature/colors and names

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -4,7 +4,7 @@ dependencies {
     api('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-228-GTNH:dev')
     api('com.github.GTNewHorizons:bdlib:1.9.8-GTNH:dev')
 
-    compileOnly('com.github.GTNewHorizons:waila:1.6.0:dev') {transitive=false}
+    implementation('com.github.GTNewHorizons:waila:1.6.0:dev') {transitive=false}
     compileOnly('com.github.GTNewHorizons:NotEnoughItems:2.3.55-GTNH:dev')
     compileOnly('com.github.GTNewHorizons:BuildCraft:7.1.34:dev')
 }

--- a/src/main/resources/assets/ae2stuff/lang/en_US.lang
+++ b/src/main/resources/assets/ae2stuff/lang/en_US.lang
@@ -16,6 +16,7 @@ ae2stuff.waila.wireless.connected=Connected to %s,%s,%s
 ae2stuff.waila.wireless.notconnected=Not Connected
 ae2stuff.waila.wireless.channels=Channels: %s
 ae2stuff.waila.wireless.power=Power Used: %s AE/t
+ae2stuff.waila.wireless.name=Name: %s
 
 ae2stuff.gui.lock.on=Locked - Can't be removed with automation
 ae2stuff.gui.lock.off=Unlocked - Can be removed with automation

--- a/src/main/scala/net/bdew/ae2stuff/machines/wireless/BlockWireless.scala
+++ b/src/main/scala/net/bdew/ae2stuff/machines/wireless/BlockWireless.scala
@@ -9,6 +9,7 @@
 
 package net.bdew.ae2stuff.machines.wireless
 
+import appeng.items.tools.quartz.ToolQuartzCuttingKnife
 import cpw.mods.fml.relauncher.{Side, SideOnly}
 import net.bdew.ae2stuff.misc.{BlockWrenchable, MachineMaterial}
 import net.bdew.lib.Misc
@@ -49,8 +50,13 @@ object BlockWireless
       player: EntityLivingBase,
       stack: ItemStack
   ): Unit = {
-    if (player.isInstanceOf[EntityPlayer])
-      getTE(world, x, y, z).placingPlayer = player.asInstanceOf[EntityPlayer]
+    if (player.isInstanceOf[EntityPlayer]) {
+      val te = getTE(world, x, y, z)
+      te.placingPlayer = player.asInstanceOf[EntityPlayer]
+      if (stack != null && stack.hasDisplayName) {
+        te.customName = stack.getDisplayName
+      }
+    }
   }
 
   override def onBlockActivatedReal(
@@ -63,7 +69,15 @@ object BlockWireless
       xOffs: Float,
       yOffs: Float,
       zOffs: Float
-  ): Boolean = false
+  ): Boolean = {
+    val item = player.getHeldItem
+    if (item != null && item.getItem.isInstanceOf[ToolQuartzCuttingKnife]) {
+      if (!world.isRemote) {
+        return true
+      }
+    }
+    false
+  }
 
   var icon_on_side: IIcon = null
   var icon_off_side: IIcon = null

--- a/src/main/scala/net/bdew/ae2stuff/machines/wireless/TileWireless.scala
+++ b/src/main/scala/net/bdew/ae2stuff/machines/wireless/TileWireless.scala
@@ -11,18 +11,27 @@ package net.bdew.ae2stuff.machines.wireless
 
 import java.util
 import appeng.api.AEApi
+import appeng.api.implementations.tiles.IColorableTile
 import appeng.api.networking.{GridFlags, IGridConnection}
+import appeng.api.util.AEColor
+import appeng.me.helpers.AENetworkProxy
 import net.bdew.ae2stuff.AE2Stuff
 import net.bdew.ae2stuff.grid.{GridTile, VariableIdlePower}
 import net.bdew.lib.block.BlockRef
 import net.bdew.lib.data.base.{TileDataSlots, UpdateKind}
 import net.bdew.lib.multiblock.data.DataSlotPos
 import net.minecraft.block.Block
+import net.minecraft.entity.player.EntityPlayer
 import net.minecraft.item.ItemStack
 import net.minecraft.nbt.NBTTagCompound
 import net.minecraft.world.World
+import net.minecraftforge.common.util.ForgeDirection
 
-class TileWireless extends TileDataSlots with GridTile with VariableIdlePower {
+class TileWireless
+    extends TileDataSlots
+    with GridTile
+    with VariableIdlePower
+    with IColorableTile {
   val cfg = MachineWireless
 
   val link =
@@ -33,6 +42,7 @@ class TileWireless extends TileDataSlots with GridTile with VariableIdlePower {
   lazy val myPos = BlockRef.fromTile(this)
 
   var customName: String = ""
+  var color: AEColor = AEColor.Transparent
   def isLinked = link.isDefined
   def getLink = link flatMap (_.getTile[TileWireless](worldObj))
 
@@ -151,10 +161,32 @@ class TileWireless extends TileDataSlots with GridTile with VariableIdlePower {
     if (customName != "") {
       t.setString("CustomName", customName)
     }
+    t.setString("CustomName", customName)
+    t.setShort("Color", color.ordinal().toShort)
   }
 
   override def doLoad(kind: UpdateKind.Value, t: NBTTagCompound): Unit = {
     super.doLoad(kind, t)
     this.customName = t.getString("CustomName")
+    if (!t.hasKey("Color")) {
+      t.setShort("Color", AEColor.Transparent.ordinal().toShort)
+    }
+    val colorIdx = t.getShort("Color").toInt
+    this.color = AEColor.values().apply(colorIdx)
   }
+
+  override def recolourBlock(
+      side: ForgeDirection,
+      colour: AEColor,
+      who: EntityPlayer
+  ): Boolean = {
+    this.color = colour
+    true
+  }
+
+  override def getConnectableSides: util.EnumSet[ForgeDirection] =
+    super.getConnectableSides
+  override def getColor: AEColor = color
+
+  override def getGridColor: AEColor = color
 }

--- a/src/main/scala/net/bdew/ae2stuff/machines/wireless/TileWireless.scala
+++ b/src/main/scala/net/bdew/ae2stuff/machines/wireless/TileWireless.scala
@@ -10,7 +10,6 @@
 package net.bdew.ae2stuff.machines.wireless
 
 import java.util
-
 import appeng.api.AEApi
 import appeng.api.networking.{GridFlags, IGridConnection}
 import net.bdew.ae2stuff.AE2Stuff
@@ -20,6 +19,7 @@ import net.bdew.lib.data.base.{TileDataSlots, UpdateKind}
 import net.bdew.lib.multiblock.data.DataSlotPos
 import net.minecraft.block.Block
 import net.minecraft.item.ItemStack
+import net.minecraft.nbt.NBTTagCompound
 import net.minecraft.world.World
 
 class TileWireless extends TileDataSlots with GridTile with VariableIdlePower {
@@ -32,6 +32,7 @@ class TileWireless extends TileDataSlots with GridTile with VariableIdlePower {
 
   lazy val myPos = BlockRef.fromTile(this)
 
+  var customName: String = ""
   def isLinked = link.isDefined
   def getLink = link flatMap (_.getTile[TileWireless](worldObj))
 
@@ -58,6 +59,7 @@ class TileWireless extends TileDataSlots with GridTile with VariableIdlePower {
   def doLink(other: TileWireless): Boolean = {
     if (other.link.isEmpty) {
       other.link.set(myPos)
+      this.customName = other.customName
       link.set(other.myPos)
       setupConnection()
     } else false
@@ -143,4 +145,16 @@ class TileWireless extends TileDataSlots with GridTile with VariableIdlePower {
       z: Int
   ): Boolean =
     newBlock != BlockWireless
+
+  override def doSave(kind: UpdateKind.Value, t: NBTTagCompound): Unit = {
+    super.doSave(kind, t)
+    if (customName != "") {
+      t.setString("CustomName", customName)
+    }
+  }
+
+  override def doLoad(kind: UpdateKind.Value, t: NBTTagCompound): Unit = {
+    super.doLoad(kind, t)
+    this.customName = t.getString("CustomName")
+  }
 }

--- a/src/main/scala/net/bdew/ae2stuff/waila/WailaWirelessDataProvider.scala
+++ b/src/main/scala/net/bdew/ae2stuff/waila/WailaWirelessDataProvider.scala
@@ -10,6 +10,7 @@
 package net.bdew.ae2stuff.waila
 
 import appeng.api.config.PowerMultiplier
+import appeng.api.util.AEColor
 import mcp.mobius.waila.api.{IWailaConfigHandler, IWailaDataAccessor}
 import net.bdew.ae2stuff.machines.wireless.TileWireless
 import net.bdew.lib.block.BlockRef
@@ -44,14 +45,19 @@ object WailaWirelessDataProvider
                            te.connection.getUsedChannels
                          else 0),
           "power" -> PowerMultiplier.CONFIG.multiply(te.getIdlePowerUsage),
-          "name" -> te.customName
+          "name" -> te.customName,
+          "color" -> te.color.ordinal()
         )
       )
     } else {
-      tag.setTag("wireless_waila", NBT(
-        "connected" -> false,
-        "name" -> te.customName
-      ))
+      tag.setTag(
+        "wireless_waila",
+        NBT(
+          "connected" -> false,
+          "name" -> te.customName,
+          "color" -> te.color.ordinal()
+        )
+      )
     }
     tag
   }
@@ -65,6 +71,7 @@ object WailaWirelessDataProvider
     if (acc.getNBTData.hasKey("wireless_waila")) {
       val data = acc.getNBTData.getCompoundTag("wireless_waila")
       val name = data.getString("name")
+      val color = data.getInteger("color")
       if (data.getBoolean("connected")) {
         val pos = BlockRef.fromNBT(data.getCompoundTag("target"))
         List(
@@ -78,10 +85,21 @@ object WailaWirelessDataProvider
             "ae2stuff.waila.wireless.power",
             DecFormat.short(data.getDouble("power"))
           )
-        ).++(if (name != "") Misc.toLocalF("ae2stuff.waila.wireless.name", name)::Nil else Nil)
+        )
+          .++(if (name != "") {
+            Misc.toLocalF("ae2stuff.waila.wireless.name", name) :: Nil
+          } else Nil)
+          .++(if (color != AEColor.Transparent.ordinal()) {
+            Misc.toLocal(AEColor.values().apply(color).unlocalizedName) :: Nil
+          } else Nil)
       } else {
         List(Misc.toLocal("ae2stuff.waila.wireless.notconnected"))
-          .++(if (name != "") Misc.toLocalF("ae2stuff.waila.wireless.name", name)::Nil else Nil)
+          .++(if (name != "") {
+            Misc.toLocalF("ae2stuff.waila.wireless.name", name) :: Nil
+          } else Nil)
+          .++(if (color != AEColor.Transparent.ordinal()) {
+            Misc.toLocal(AEColor.values().apply(color).unlocalizedName) :: Nil
+          } else Nil)
       }
     } else List.empty
   }

--- a/src/main/scala/net/bdew/ae2stuff/waila/WailaWirelessDataProvider.scala
+++ b/src/main/scala/net/bdew/ae2stuff/waila/WailaWirelessDataProvider.scala
@@ -43,11 +43,15 @@ object WailaWirelessDataProvider
           "channels" -> (if (te.connection != null)
                            te.connection.getUsedChannels
                          else 0),
-          "power" -> PowerMultiplier.CONFIG.multiply(te.getIdlePowerUsage)
+          "power" -> PowerMultiplier.CONFIG.multiply(te.getIdlePowerUsage),
+          "name" -> te.customName
         )
       )
     } else {
-      tag.setTag("wireless_waila", NBT("connected" -> false))
+      tag.setTag("wireless_waila", NBT(
+        "connected" -> false,
+        "name" -> te.customName
+      ))
     }
     tag
   }
@@ -60,6 +64,7 @@ object WailaWirelessDataProvider
   ): Iterable[String] = {
     if (acc.getNBTData.hasKey("wireless_waila")) {
       val data = acc.getNBTData.getCompoundTag("wireless_waila")
+      val name = data.getString("name")
       if (data.getBoolean("connected")) {
         val pos = BlockRef.fromNBT(data.getCompoundTag("target"))
         List(
@@ -73,9 +78,10 @@ object WailaWirelessDataProvider
             "ae2stuff.waila.wireless.power",
             DecFormat.short(data.getDouble("power"))
           )
-        )
+        ).++(if (name != "") Misc.toLocalF("ae2stuff.waila.wireless.name", name)::Nil else Nil)
       } else {
         List(Misc.toLocal("ae2stuff.waila.wireless.notconnected"))
+          .++(if (name != "") Misc.toLocalF("ae2stuff.waila.wireless.name", name)::Nil else Nil)
       }
     } else List.empty
   }


### PR DESCRIPTION
Adds colors and names to wireless

1. Doesn't actually let you recolor them though because AE2 color applicator doesn't let you (yet). see https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/364
2. Doesn't actually let you rename them using a quartz knife because the knife doesn't let you. You have to use an anvil or tool station from TiC