### PR TITLE
Fix packet sending a list of useless info

### DIFF
--- a/src/main/scala/net/bdew/ae2stuff/items/visualiser/data.scala
+++ b/src/main/scala/net/bdew/ae2stuff/items/visualiser/data.scala
@@ -94,5 +94,4 @@ object VisualisationData {
 
 object VisualisationModes extends Enumeration {
   val FULL, NODES, CHANNELS, NONUM, P2P = Value
-  val modes = List(FULL, NODES, CHANNELS, NONUM, P2P)
 }

--- a/src/main/scala/net/bdew/ae2stuff/misc/MouseEventHandler.scala
+++ b/src/main/scala/net/bdew/ae2stuff/misc/MouseEventHandler.scala
@@ -10,17 +10,15 @@
 package net.bdew.ae2stuff.misc
 
 import cpw.mods.fml.common.eventhandler.SubscribeEvent
-import net.bdew.ae2stuff.items.visualiser.{
-  ItemVisualiser,
-  VisualisationModes,
-  VisualiserOverlayRender
-}
+import net.bdew.ae2stuff.items.visualiser.{ItemVisualiser, VisualisationModes, VisualiserOverlayRender}
 import net.bdew.ae2stuff.network.{MsgVisualisationMode, NetHandler}
 import net.bdew.lib.{Client, Misc}
 import net.minecraftforge.client.event.MouseEvent
 import net.minecraftforge.common.MinecraftForge
 
 object MouseEventHandler {
+  private val VISUALISATION_MODES = VisualisationModes.values.toList
+
   def init(): Unit = {
     MinecraftForge.EVENT_BUS.register(this)
   }
@@ -37,12 +35,12 @@ object MouseEventHandler {
       val newMode =
         if (ev.dwheel.signum > 0)
           Misc.nextInSeq(
-            VisualisationModes.modes,
+            VISUALISATION_MODES,
             ItemVisualiser.getMode(stack)
           )
         else
           Misc.prevInSeq(
-            VisualisationModes.modes,
+            VISUALISATION_MODES,
             ItemVisualiser.getMode(stack)
           )
       ItemVisualiser.setMode(stack, newMode)


### PR DESCRIPTION
This caused the packet verification to fail since List wasn't on the whitelist. Solution is to not send the list in the first place