### PR TITLE
Use the quartz knife to rename wireless

### DIFF
--- a/src/main/scala/net/bdew/ae2stuff/machines/wireless/BlockWireless.scala
+++ b/src/main/scala/net/bdew/ae2stuff/machines/wireless/BlockWireless.scala
@@ -10,7 +10,10 @@
 package net.bdew.ae2stuff.machines.wireless
 
 import appeng.api.util.AEColor
+import appeng.core.AppEng
+import appeng.core.sync.GuiBridge
 import appeng.items.tools.quartz.ToolQuartzCuttingKnife
+import appeng.util.Platform
 import cpw.mods.fml.relauncher.{Side, SideOnly}
 import net.bdew.ae2stuff.misc.{BlockWrenchable, MachineMaterial}
 import net.bdew.lib.Misc
@@ -74,7 +77,16 @@ object BlockWireless
   ): Boolean = {
     val item = player.getHeldItem
     if (item != null && item.getItem.isInstanceOf[ToolQuartzCuttingKnife]) {
-      if (!world.isRemote) {
+      val te = world.getTileEntity(x, y, z)
+      if (te.isInstanceOf[TileWireless]) {
+        player.openGui(
+          AppEng.instance,
+          (GuiBridge.GUI_RENAMER.ordinal << 5) | side,
+          world,
+          te.xCoord,
+          te.yCoord,
+          te.zCoord
+        )
         return true
       }
     }

--- a/src/main/scala/net/bdew/ae2stuff/machines/wireless/TileWireless.scala
+++ b/src/main/scala/net/bdew/ae2stuff/machines/wireless/TileWireless.scala
@@ -12,8 +12,10 @@ package net.bdew.ae2stuff.machines.wireless
 import java.util
 import appeng.api.AEApi
 import appeng.api.implementations.tiles.IColorableTile
-import appeng.api.networking.{GridFlags, IGridConnection}
+import appeng.api.networking.security.IActionHost
+import appeng.api.networking.{GridFlags, IGridConnection, IGridNode}
 import appeng.api.util.AEColor
+import appeng.helpers.ICustomNameObject
 import net.bdew.ae2stuff.AE2Stuff
 import net.bdew.ae2stuff.grid.{GridTile, VariableIdlePower}
 import net.bdew.lib.block.BlockRef
@@ -30,7 +32,9 @@ import net.minecraftforge.common.util.ForgeDirection
 class TileWireless
     extends TileDataSlots
     with GridTile
+    with IActionHost
     with VariableIdlePower
+    with ICustomNameObject
     with IColorableTile {
   val cfg = MachineWireless
 
@@ -41,7 +45,7 @@ class TileWireless
 
   lazy val myPos = BlockRef.fromTile(this)
 
-  var customName: String = ""
+  var customName: String = null
   var color: AEColor = AEColor.Transparent
   def isLinked = link.isDefined
   def getLink = link flatMap (_.getTile[TileWireless](worldObj))
@@ -158,16 +162,17 @@ class TileWireless
 
   override def doSave(kind: UpdateKind.Value, t: NBTTagCompound): Unit = {
     super.doSave(kind, t)
-    if (customName != "") {
+    if (customName != null) {
       t.setString("CustomName", customName)
     }
-    t.setString("CustomName", customName)
     t.setShort("Color", color.ordinal().toShort)
   }
 
   override def doLoad(kind: UpdateKind.Value, t: NBTTagCompound): Unit = {
     super.doLoad(kind, t)
-    this.customName = t.getString("CustomName")
+    if (t.hasKey("CustomName")) {
+      this.customName = t.getString("CustomName")
+    }
     if (!t.hasKey("Color")) {
       t.setShort("Color", AEColor.Transparent.ordinal().toShort)
     }
@@ -197,7 +202,7 @@ class TileWireless
     if (getGridNode(side) != null) {
       getGridNode(side).updateState()
       worldObj.markBlockForUpdate(xCoord, yCoord, zCoord)
-//      markDirty()
+      markDirty()
     }
     true
   }
@@ -205,4 +210,15 @@ class TileWireless
   override def getColor: AEColor = color
 
   override def getGridColor: AEColor = color
+
+  override def getCustomName: String = customName
+
+  override def hasCustomName: Boolean = customName != null
+
+  override def setCustomName(name: String): Unit = {
+    this.customName = name
+    this.getLink.foreach(te => te.customName = name)
+    markDirty()
+  }
+  override def getActionableNode: IGridNode = this.node
 }

--- a/src/main/scala/net/bdew/ae2stuff/waila/WailaWirelessDataProvider.scala
+++ b/src/main/scala/net/bdew/ae2stuff/waila/WailaWirelessDataProvider.scala
@@ -36,28 +36,28 @@ object WailaWirelessDataProvider
       val pos = te.link map (link =>
         NBT.from(link.writeToNBT _)
       ) getOrElse new NBTTagCompound
-      tag.setTag(
-        "wireless_waila",
-        NBT(
-          "connected" -> true,
-          "target" -> pos,
-          "channels" -> (if (te.connection != null)
-                           te.connection.getUsedChannels
-                         else 0),
-          "power" -> PowerMultiplier.CONFIG.multiply(te.getIdlePowerUsage),
-          "name" -> te.customName,
-          "color" -> te.color.ordinal()
-        )
+      val data = NBT(
+        "connected" -> true,
+        "target" -> pos,
+        "channels" -> (if (te.connection != null)
+                         te.connection.getUsedChannels
+                       else 0),
+        "power" -> PowerMultiplier.CONFIG.multiply(te.getIdlePowerUsage),
+        "color" -> te.color.ordinal()
       )
+      if (te.hasCustomName) {
+        data.setString("name", te.customName)
+      }
+      tag.setTag("wireless_waila", data)
     } else {
-      tag.setTag(
-        "wireless_waila",
-        NBT(
-          "connected" -> false,
-          "name" -> te.customName,
-          "color" -> te.color.ordinal()
-        )
+      val data = NBT(
+        "connected" -> false,
+        "color" -> te.color.ordinal()
       )
+      if (te.hasCustomName) {
+        data.setString("name", te.customName)
+      }
+      tag.setTag("wireless_waila", data)
     }
     tag
   }
@@ -70,7 +70,7 @@ object WailaWirelessDataProvider
   ): Iterable[String] = {
     if (acc.getNBTData.hasKey("wireless_waila")) {
       val data = acc.getNBTData.getCompoundTag("wireless_waila")
-      val name = data.getString("name")
+      val name = if (data.hasKey("name")) data.getString("name") else null
       val color = data.getInteger("color")
       if (data.getBoolean("connected")) {
         val pos = BlockRef.fromNBT(data.getCompoundTag("target"))
@@ -86,7 +86,7 @@ object WailaWirelessDataProvider
             DecFormat.short(data.getDouble("power"))
           )
         )
-          .++(if (name != "") {
+          .++(if (name != null) {
             Misc.toLocalF("ae2stuff.waila.wireless.name", name) :: Nil
           } else Nil)
           .++(if (color != AEColor.Transparent.ordinal()) {
@@ -94,7 +94,7 @@ object WailaWirelessDataProvider
           } else Nil)
       } else {
         List(Misc.toLocal("ae2stuff.waila.wireless.notconnected"))
-          .++(if (name != "") {
+          .++(if (name != null) {
             Misc.toLocalF("ae2stuff.waila.wireless.name", name) :: Nil
           } else Nil)
           .++(if (color != AEColor.Transparent.ordinal()) {


### PR DESCRIPTION
Title, I like scala now /:(
Gave it the possibility of having no name instead of giving everything an empty string but existing wireless blocks will have a floating string tag like this. 
![image](https://github.com/GTNewHorizons/ae2stuff/assets/49818773/b6917976-07f5-4e03-bca7-f2d35b38a824)
I can change it so empty string == null string but rn I'm lazy