### PR TITLE
Fix ghost TE creation on breaking wireless in survival mode.

### DIFF
--- a/src/main/scala/net/bdew/ae2stuff/machines/wireless/BlockWireless.scala
+++ b/src/main/scala/net/bdew/ae2stuff/machines/wireless/BlockWireless.scala
@@ -39,6 +39,8 @@ object BlockWireless
 
   setHardness(1)
 
+  private var tempColor: AEColor = AEColor.Transparent
+
   override def getDrops(
       world: World,
       x: Int,
@@ -48,9 +50,8 @@ object BlockWireless
       fortune: Int
   ): util.ArrayList[ItemStack] = {
     val stack = new ItemStack(this)
-    val te = getTE(world, x, y, z)
-    if (te.color != AEColor.Transparent) {
-      stack.setItemDamage(te.color.ordinal() + 1)
+    if (tempColor != AEColor.Transparent) {
+      stack.setItemDamage(tempColor.ordinal() + 1)
     }
     val drops = new util.ArrayList[ItemStack]()
     drops.add(stack)
@@ -93,7 +94,9 @@ object BlockWireless
       block: Block,
       meta: Int
   ): Unit = {
-    getTE(world, x, y, z).doUnlink()
+    val te = getTE(world, x, y, z);
+    te.doUnlink()
+    tempColor = te.color
     super.breakBlock(world, x, y, z, block, meta)
   }
 

--- a/src/main/scala/net/bdew/ae2stuff/machines/wireless/BlockWireless.scala
+++ b/src/main/scala/net/bdew/ae2stuff/machines/wireless/BlockWireless.scala
@@ -39,8 +39,6 @@ object BlockWireless
 
   setHardness(1)
 
-  private var tempColor: AEColor = AEColor.Transparent
-
   override def getDrops(
       world: World,
       x: Int,
@@ -50,8 +48,9 @@ object BlockWireless
       fortune: Int
   ): util.ArrayList[ItemStack] = {
     val stack = new ItemStack(this)
-    if (tempColor != AEColor.Transparent) {
-      stack.setItemDamage(tempColor.ordinal() + 1)
+    val te = world.getTileEntity(x, y, z).asInstanceOf[TileWireless]
+    if (te != null && te.color != AEColor.Transparent) {
+      stack.setItemDamage(te.color.ordinal() + 1)
     }
     val drops = new util.ArrayList[ItemStack]()
     drops.add(stack)
@@ -94,9 +93,7 @@ object BlockWireless
       block: Block,
       meta: Int
   ): Unit = {
-    val te = getTE(world, x, y, z);
-    te.doUnlink()
-    tempColor = te.color
+    getTE(world, x, y, z).doUnlink()
     super.breakBlock(world, x, y, z, block, meta)
   }
 


### PR DESCRIPTION
When getDrops() called TE already non exist, so getTE() is create new one.
Wrench pick up not affected.

Before:

![image](https://github.com/user-attachments/assets/daa8baf2-73da-4a81-9984-0f6cd4115e9c)

After:

![image](https://github.com/user-attachments/assets/5fb2da63-d36c-4cd7-b0d7-5dd0234098c5)


