### PR TITLE
Network Visualizer shows connections between a Crafting Input Bus/Buffer and its proxies.

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,11 +1,14 @@
 // Add your dependencies here
 
 dependencies {
-    api('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-629-GTNH:dev')
-    api('com.github.GTNewHorizons:bdlib:1.10.0-GTNH:dev')
-    api('com.github.GTNewHorizons:GTNHLib:0.6.27:dev')
+    api('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-643-GTNH:dev')
+    api('com.github.GTNewHorizons:bdlib:1.11.0-GTNH:dev')
+    api('com.github.GTNewHorizons:GTNHLib:0.6.32:dev')
 
-    implementation('com.github.GTNewHorizons:waila:1.8.7:dev') {transitive=false}
-    compileOnly('com.github.GTNewHorizons:NotEnoughItems:2.7.51-GTNH:dev')
+    implementation('com.github.GTNewHorizons:waila:1.8.8:dev') {transitive=false}
+    compileOnly('com.github.GTNewHorizons:NotEnoughItems:2.7.58-GTNH:dev')
     compileOnly('com.github.GTNewHorizons:BuildCraft:7.1.43:dev')
+    compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.51.355:dev')
+
+    runtimeOnly('com.github.GTNewHorizons:Baubles-Expanded:2.1.9-GTNH:dev')
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -11,5 +11,5 @@ dependencies {
     
     compileOnly('com.github.GTNewHorizons:NotEnoughItems:2.7.72-GTNH:dev')
     compileOnly('com.github.GTNewHorizons:BuildCraft:7.1.44:dev')
-    compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.51.355:dev')
+    compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.52.00:dev')
 }

--- a/repositories.gradle
+++ b/repositories.gradle
@@ -15,5 +15,4 @@ repositories {
     maven {
         url 'https://jitpack.io'
     }
-    mavenLocal()
 }

--- a/repositories.gradle
+++ b/repositories.gradle
@@ -15,4 +15,5 @@ repositories {
     maven {
         url 'https://jitpack.io'
     }
+    mavenLocal()
 }

--- a/src/main/resources/assets/ae2stuff/lang/en_US.lang
+++ b/src/main/resources/assets/ae2stuff/lang/en_US.lang
@@ -63,6 +63,7 @@ ae2stuff.visualiser.mode.nodes=Show Nodes
 ae2stuff.visualiser.mode.channels=Show Channels
 ae2stuff.visualiser.mode.nonum=Show Channels and Nodes
 ae2stuff.visualiser.mode.p2p=Show P2P Links
+ae2stuff.visualiser.mode.proxy=Show Crafting Input Proxy Links
 
 itemGroup.bdew.ae2stuff=AE2 Stuff
 ae2stuff.key.mode=Mode Switch

--- a/src/main/scala/net/bdew/ae2stuff/AE2Stuff.scala
+++ b/src/main/scala/net/bdew/ae2stuff/AE2Stuff.scala
@@ -12,7 +12,7 @@ package net.bdew.ae2stuff
 import com.gtnewhorizon.gtnhlib.keybind.SyncedKeybind
 
 import java.io.File
-import cpw.mods.fml.common.Mod
+import cpw.mods.fml.common.{Loader, Mod}
 import cpw.mods.fml.common.Mod.EventHandler
 import cpw.mods.fml.common.event._
 import cpw.mods.fml.common.network.NetworkRegistry
@@ -55,6 +55,8 @@ object AE2Stuff {
     Keyboard.CHAR_NONE
   )
 
+  var isGTloaded = false
+
   def logDebug(msg: String, args: Any*) = log.debug(msg.format(args: _*))
   def logInfo(msg: String, args: Any*) = log.info(msg.format(args: _*))
   def logWarn(msg: String, args: Any*) = log.warn(msg.format(args: _*))
@@ -71,6 +73,7 @@ object AE2Stuff {
     TuningLoader.loadConfigFiles()
     Machines.load()
     Items.load()
+    isGTloaded = Loader.isModLoaded("gregtech")
   }
 
   @EventHandler

--- a/src/main/scala/net/bdew/ae2stuff/items/visualiser/ItemVisualiser.scala
+++ b/src/main/scala/net/bdew/ae2stuff/items/visualiser/ItemVisualiser.scala
@@ -167,11 +167,11 @@ object ItemVisualiser extends SimpleItem("Visualiser") with ItemLocationStore {
                 val proxyFlag = VNodeFlags.ValueSet.apply(VNodeFlags.PROXY)
                 val linkFlag = VLinkFlags.ValueSet.apply(VLinkFlags.PROXY)
                 for {
-                  proxy <- node.getMachine
+                  proxyHatch <- node.getMachine
                     .asInstanceOf[MTEHatchCraftingInputME]
-                    .getProxies
+                    .getProxyHatches
                 } {
-                  val BMTE = proxy.getBaseMetaTileEntity
+                  val BMTE = proxyHatch.getBaseMetaTileEntity
                   val proxyNode = VNode(
                     BMTE.getXCoord,
                     BMTE.getYCoord,

--- a/src/main/scala/net/bdew/ae2stuff/items/visualiser/ItemVisualiser.scala
+++ b/src/main/scala/net/bdew/ae2stuff/items/visualiser/ItemVisualiser.scala
@@ -11,8 +11,11 @@ package net.bdew.ae2stuff.items.visualiser
 
 import java.util
 import java.util.Locale
-
 import appeng.api.networking.{GridFlags, IGridConnection, IGridHost}
+import appeng.me.GridNode
+import cpw.mods.fml.common.Loader
+import gregtech.common.tileentities.machines.MTEHatchCraftingInputME
+import net.bdew.ae2stuff.AE2Stuff
 import net.bdew.ae2stuff.misc.ItemLocationStore
 import net.bdew.ae2stuff.network.{
   MsgVisualisationData,
@@ -122,7 +125,7 @@ object ItemVisualiser extends SimpleItem("Visualiser") with ItemLocationStore {
         import scala.collection.JavaConversions._
         var seen = Set.empty[IGridConnection]
         var connections = Set.empty[IGridConnection]
-        val nodes = (for (node <- grid.getNodes) yield {
+        var nodes = (for (node <- grid.getNodes) yield {
           val block = node.getGridBlock
           if (block.isWorldAccessible && block.getLocation.isInWorld(world)) {
             val loc = block.getLocation
@@ -135,7 +138,7 @@ object ItemVisualiser extends SimpleItem("Visualiser") with ItemLocationStore {
           } else None
         }).flatten.toMap
 
-        val connList = for {
+        var connList = for {
           c <- connections
           n1 <- nodes.get(c.a())
           n2 <- nodes.get(c.b()) if n1 != n2
@@ -152,6 +155,35 @@ object ItemVisualiser extends SimpleItem("Visualiser") with ItemLocationStore {
               .hasFlag(GridFlags.CANNOT_CARRY_COMPRESSED)
           ) flags += VLinkFlags.COMPRESSED
           VLink(n1, n2, c.getUsedChannels, flags)
+        }
+
+        if (AE2Stuff.isGTloaded) {
+          for {
+            node <- grid.getNodes
+          } {
+            val block = node.getGridBlock
+            if (block.isWorldAccessible && block.getLocation.isInWorld(world)) {
+              if (node.getMachine.isInstanceOf[MTEHatchCraftingInputME]) {
+                val proxyFlag = VNodeFlags.ValueSet.apply(VNodeFlags.PROXY)
+                val linkFlag = VLinkFlags.ValueSet.apply(VLinkFlags.PROXY)
+                for {
+                  proxy <- node.getMachine
+                    .asInstanceOf[MTEHatchCraftingInputME]
+                    .getProxies
+                } {
+                  val BMTE = proxy.getBaseMetaTileEntity
+                  val proxyNode = VNode(
+                    BMTE.getXCoord,
+                    BMTE.getYCoord,
+                    BMTE.getZCoord,
+                    proxyFlag
+                  )
+                  nodes ++= Some(new GridNode(null) -> proxyNode)
+                  connList ++= Some(VLink(nodes(node), proxyNode, 0, linkFlag))
+                }
+              }
+            }
+          }
         }
 
         NetHandler.sendTo(

--- a/src/main/scala/net/bdew/ae2stuff/items/visualiser/VisualiserOverlayRender.scala
+++ b/src/main/scala/net/bdew/ae2stuff/items/visualiser/VisualiserOverlayRender.scala
@@ -43,9 +43,9 @@ object VisualiserOverlayRender extends WorldOverlayRenderer {
         case VisualisationModes.NODES => !node.flags.contains(VNodeFlags.PROXY)
         case VisualisationModes.CHANNELS => false
         case VisualisationModes.NONUM => !node.flags.contains(VNodeFlags.PROXY)
-        case VisualisationModes.P2P => false
+        case VisualisationModes.P2P   => false
         case VisualisationModes.PROXY => node.flags.contains(VNodeFlags.PROXY)
-        case _ => true
+        case _                        => true
       })
     ) {
       val color =
@@ -200,20 +200,26 @@ object VisualiserOverlayRender extends WorldOverlayRenderer {
     tess.draw()
   }
 
-  def renderLinks(links: Seq[VLink], width: Float, mode: VisualisationModes.Value): Unit = {
+  def renderLinks(
+      links: Seq[VLink],
+      width: Float,
+      mode: VisualisationModes.Value
+  ): Unit = {
     GL11.glLineWidth(width)
     val tess = Tessellator.instance
     tess.startDrawing(GL11.GL_LINES)
 
     for (
       link <- links if (mode match {
-          case VisualisationModes.NODES => false
-          case VisualisationModes.CHANNELS => !link.flags.contains(VLinkFlags.PROXY)
-          case VisualisationModes.NONUM => !link.flags.contains(VLinkFlags.PROXY)
-          case VisualisationModes.P2P => link.flags.contains(VLinkFlags.COMPRESSED)
-          case VisualisationModes.PROXY => link.flags.contains(VLinkFlags.PROXY)
-          case _ => true
-        })
+        case VisualisationModes.NODES => false
+        case VisualisationModes.CHANNELS =>
+          !link.flags.contains(VLinkFlags.PROXY)
+        case VisualisationModes.NONUM => !link.flags.contains(VLinkFlags.PROXY)
+        case VisualisationModes.P2P =>
+          link.flags.contains(VLinkFlags.COMPRESSED)
+        case VisualisationModes.PROXY => link.flags.contains(VLinkFlags.PROXY)
+        case _                        => true
+      })
     ) {
       if (link.flags.contains(VLinkFlags.COMPRESSED)) {
         tess.setColorRGBA(255, 0, 255, 255)

--- a/src/main/scala/net/bdew/ae2stuff/items/visualiser/VisualiserOverlayRender.scala
+++ b/src/main/scala/net/bdew/ae2stuff/items/visualiser/VisualiserOverlayRender.scala
@@ -43,6 +43,8 @@ object VisualiserOverlayRender extends WorldOverlayRenderer {
           (255, 0, 0)
         else if (node.flags.contains(VNodeFlags.DENSE))
           (255, 255, 0)
+        else if (node.flags.contains(VNodeFlags.PROXY))
+          (255, 165, 0)
         else
           (0, 0, 255)
 
@@ -200,6 +202,8 @@ object VisualiserOverlayRender extends WorldOverlayRenderer {
         tess.setColorRGBA(255, 0, 255, 255)
       } else if (link.flags.contains(VLinkFlags.DENSE)) {
         tess.setColorRGBA(255, 255, 0, 255)
+      } else if (link.flags.contains(VLinkFlags.PROXY)) {
+        tess.setColorRGBA(255, 165, 0, 255)
       } else {
         tess.setColorRGBA(0, 0, 255, 255)
       }

--- a/src/main/scala/net/bdew/ae2stuff/items/visualiser/VisualiserOverlayRender.scala
+++ b/src/main/scala/net/bdew/ae2stuff/items/visualiser/VisualiserOverlayRender.scala
@@ -9,6 +9,7 @@
 
 package net.bdew.ae2stuff.items.visualiser
 
+import net.bdew.ae2stuff.items.visualiser
 import net.bdew.ae2stuff.misc.{OverlayRenderHandler, WorldOverlayRenderer}
 import net.bdew.ae2stuff.network.{MsgVisualisationData, NetHandler}
 import net.bdew.lib.Client
@@ -33,11 +34,20 @@ object VisualiserOverlayRender extends WorldOverlayRenderer {
     needListRefresh = true
   }
 
-  def renderNodes(): Unit = {
+  def renderNodes(mode: VisualisationModes.Value): Unit = {
     val tess = Tessellator.instance
     tess.startDrawing(GL11.GL_QUADS)
 
-    for (node <- currentLinks.nodes) {
+    for (
+      node <- currentLinks.nodes if (mode match {
+        case VisualisationModes.NODES => !node.flags.contains(VNodeFlags.PROXY)
+        case VisualisationModes.CHANNELS => false
+        case VisualisationModes.NONUM => !node.flags.contains(VNodeFlags.PROXY)
+        case VisualisationModes.P2P => false
+        case VisualisationModes.PROXY => node.flags.contains(VNodeFlags.PROXY)
+        case _ => true
+      })
+    ) {
       val color =
         if (node.flags.contains(VNodeFlags.MISSING))
           (255, 0, 0)
@@ -190,13 +200,20 @@ object VisualiserOverlayRender extends WorldOverlayRenderer {
     tess.draw()
   }
 
-  def renderLinks(links: Seq[VLink], width: Float, onlyP2P: Boolean): Unit = {
+  def renderLinks(links: Seq[VLink], width: Float, mode: VisualisationModes.Value): Unit = {
     GL11.glLineWidth(width)
     val tess = Tessellator.instance
     tess.startDrawing(GL11.GL_LINES)
 
     for (
-      link <- links if (!onlyP2P) || link.flags.contains(VLinkFlags.COMPRESSED)
+      link <- links if (mode match {
+          case VisualisationModes.NODES => false
+          case VisualisationModes.CHANNELS => !link.flags.contains(VLinkFlags.PROXY)
+          case VisualisationModes.NONUM => !link.flags.contains(VLinkFlags.PROXY)
+          case VisualisationModes.P2P => link.flags.contains(VLinkFlags.COMPRESSED)
+          case VisualisationModes.PROXY => link.flags.contains(VLinkFlags.PROXY)
+          case _ => true
+        })
     ) {
       if (link.flags.contains(VLinkFlags.COMPRESSED)) {
         tess.setColorRGBA(255, 0, 255, 255)
@@ -226,13 +243,15 @@ object VisualiserOverlayRender extends WorldOverlayRenderer {
   val renderNodesModes = Set(
     VisualisationModes.NODES,
     VisualisationModes.FULL,
-    VisualisationModes.NONUM
+    VisualisationModes.NONUM,
+    VisualisationModes.PROXY
   )
   val renderLinksModes = Set(
     VisualisationModes.CHANNELS,
     VisualisationModes.FULL,
     VisualisationModes.NONUM,
-    VisualisationModes.P2P
+    VisualisationModes.P2P,
+    VisualisationModes.PROXY
   )
 
   override def doRender(
@@ -267,14 +286,14 @@ object VisualiserOverlayRender extends WorldOverlayRenderer {
       GL11.glNewList(staticList, GL11.GL_COMPILE)
 
       if (renderNodesModes.contains(mode))
-        renderNodes()
+        renderNodes(mode)
 
       GL11.glEnable(GL11.GL_LINE_SMOOTH)
       GL11.glHint(GL11.GL_LINE_SMOOTH_HINT, GL11.GL_NICEST)
 
       if (renderLinksModes.contains(mode)) {
-        renderLinks(dense, 16f, mode == VisualisationModes.P2P)
-        renderLinks(normal, 4f, mode == VisualisationModes.P2P)
+        renderLinks(dense, 16f, mode)
+        renderLinks(normal, 4f, mode)
       }
 
       GL11.glEndList()

--- a/src/main/scala/net/bdew/ae2stuff/items/visualiser/data.scala
+++ b/src/main/scala/net/bdew/ae2stuff/items/visualiser/data.scala
@@ -93,5 +93,5 @@ object VisualisationData {
 }
 
 object VisualisationModes extends Enumeration {
-  val FULL, NODES, CHANNELS, NONUM, P2P = Value
+  val FULL, NODES, CHANNELS, NONUM, P2P, PROXY = Value
 }

--- a/src/main/scala/net/bdew/ae2stuff/items/visualiser/data.scala
+++ b/src/main/scala/net/bdew/ae2stuff/items/visualiser/data.scala
@@ -14,11 +14,11 @@ import java.io._
 import net.bdew.ae2stuff.AE2Stuff
 
 object VNodeFlags extends Enumeration {
-  val DENSE, MISSING = Value
+  val DENSE, MISSING, PROXY = Value
 }
 
 object VLinkFlags extends Enumeration {
-  val DENSE, COMPRESSED = Value
+  val DENSE, COMPRESSED, PROXY = Value
 }
 
 case class VNode(x: Int, y: Int, z: Int, flags: VNodeFlags.ValueSet)

--- a/src/main/scala/net/bdew/ae2stuff/misc/MouseEventHandler.scala
+++ b/src/main/scala/net/bdew/ae2stuff/misc/MouseEventHandler.scala
@@ -11,7 +11,11 @@ package net.bdew.ae2stuff.misc
 
 import cpw.mods.fml.common.eventhandler.SubscribeEvent
 import net.bdew.ae2stuff.AE2Stuff
-import net.bdew.ae2stuff.items.visualiser.{ItemVisualiser, VisualisationModes, VisualiserOverlayRender}
+import net.bdew.ae2stuff.items.visualiser.{
+  ItemVisualiser,
+  VisualisationModes,
+  VisualiserOverlayRender
+}
 import net.bdew.ae2stuff.network.{MsgVisualisationMode, NetHandler}
 import net.bdew.lib.{Client, Misc}
 import net.minecraftforge.client.event.MouseEvent

--- a/src/main/scala/net/bdew/ae2stuff/misc/MouseEventHandler.scala
+++ b/src/main/scala/net/bdew/ae2stuff/misc/MouseEventHandler.scala
@@ -10,11 +10,8 @@
 package net.bdew.ae2stuff.misc
 
 import cpw.mods.fml.common.eventhandler.SubscribeEvent
-import net.bdew.ae2stuff.items.visualiser.{
-  ItemVisualiser,
-  VisualisationModes,
-  VisualiserOverlayRender
-}
+import net.bdew.ae2stuff.AE2Stuff
+import net.bdew.ae2stuff.items.visualiser.{ItemVisualiser, VisualisationModes, VisualiserOverlayRender}
 import net.bdew.ae2stuff.network.{MsgVisualisationMode, NetHandler}
 import net.bdew.lib.{Client, Misc}
 import net.minecraftforge.client.event.MouseEvent
@@ -36,17 +33,18 @@ object MouseEventHandler {
     val stack = player.inventory.getCurrentItem
     if (stack == null || stack.getItem == null) return
     if (stack.getItem == ItemVisualiser) {
-      val newMode =
-        if (ev.dwheel.signum > 0)
-          Misc.nextInSeq(
-            VISUALISATION_MODES,
-            ItemVisualiser.getMode(stack)
-          )
-        else
-          Misc.prevInSeq(
-            VISUALISATION_MODES,
-            ItemVisualiser.getMode(stack)
-          )
+      var newMode = ItemVisualiser.getMode(stack)
+      if (ev.dwheel.signum > 0) {
+        newMode = Misc.nextInSeq(VISUALISATION_MODES, newMode)
+        if (!AE2Stuff.isGTloaded && newMode == VisualisationModes.PROXY) {
+          newMode = Misc.nextInSeq(VISUALISATION_MODES, newMode)
+        }
+      } else {
+        newMode = Misc.prevInSeq(VISUALISATION_MODES, newMode)
+        if (!AE2Stuff.isGTloaded && newMode == VisualisationModes.PROXY) {
+          newMode = Misc.prevInSeq(VISUALISATION_MODES, newMode)
+        }
+      }
       ItemVisualiser.setMode(stack, newMode)
       VisualiserOverlayRender.needListRefresh = true
       NetHandler.sendToServer(MsgVisualisationMode(newMode))


### PR DESCRIPTION
Connections are shown in orange, to distinguish from other links.

![](https://i.imgur.com/WfYLy1F.png)

Requires this GT5 PR: https://github.com/GTNewHorizons/GT5-Unofficial/pull/4511

Introduces a compile-time dependency on GT5 to ae2stuff; however the mod still runs without GT5 just fine.