### PR TITLE
Visualiser null fix

### DIFF
--- a/src/main/scala/net/bdew/ae2stuff/misc/ItemLocationStore.scala
+++ b/src/main/scala/net/bdew/ae2stuff/misc/ItemLocationStore.scala
@@ -16,8 +16,10 @@ import net.minecraft.nbt.NBTTagCompound
 
 trait ItemLocationStore extends Item {
   def hasLocation(stack: ItemStack): Boolean =
-    stack.getItem == this && stack.hasTagCompound && stack.getTagCompound
-      .hasKey("loc")
+    stack != null &&
+      stack.getItem == this &&
+      stack.hasTagCompound &&
+      stack.getTagCompound.hasKey("loc")
 
   def getLocation(stack: ItemStack): BlockRef =
     BlockRef.fromNBT(stack.getTagCompound.getCompoundTag("loc"))


### PR DESCRIPTION
EtFuturum mixed into the InventoryPlayer class so that when a player is in spectator mode, getting the main-hand item will always return null. However, ItemVisualiser still tries to fetch it without assuming the item could be null, which leads to a crash

<img width="1193" height="645" alt="image" src="https://github.com/user-attachments/assets/49c6b1ed-464d-4dbe-a1d7-27f0097d9926" />

fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21676