### PR TITLE
[Memory-opti:fix leak] fix world server memory leak in VisualiserPlayerTracker

### DIFF
--- a/src/main/scala/net/bdew/ae2stuff/AE2Stuff.scala
+++ b/src/main/scala/net/bdew/ae2stuff/AE2Stuff.scala
@@ -109,7 +109,7 @@ object AE2Stuff {
   }
 
   @EventHandler
-  def onServerStarting(event: FMLServerStartingEvent): Unit = {
+  def onServerStarting(event: FMLServerStoppedEvent): Unit = {
     VisualiserPlayerTracker.clear()
   }
 }

--- a/src/main/scala/net/bdew/ae2stuff/AE2Stuff.scala
+++ b/src/main/scala/net/bdew/ae2stuff/AE2Stuff.scala
@@ -109,7 +109,7 @@ object AE2Stuff {
   }
 
   @EventHandler
-  def onServerStarting(event: FMLServerStoppedEvent): Unit = {
+  def onServerStopped(event: FMLServerStoppedEvent): Unit = {
     VisualiserPlayerTracker.clear()
   }
 }


### PR DESCRIPTION
it was not clearing the map at the correct moment

<img width="572" height="167" alt="image" src="https://github.com/user-attachments/assets/8da007a8-1269-42ac-911a-870ad9d98efa" />
